### PR TITLE
updated tree.py

### DIFF
--- a/kolab/multiese/tree.py
+++ b/kolab/multiese/tree.py
@@ -318,13 +318,13 @@ def parse(s: str, post_processing=post_processing) -> 系列:
             else:
                 skipped -= 1
 
-        elif pos[idx] == '副詞':   # 動詞を修飾
+        elif pos[idx] == '副詞':
             x = 副詞(wakati[idx])
             buf_pos.append(x)
-        elif pos[idx] == '連体詞':   # 名詞を修飾 (TODO: 「その」「あの」など...「大きな」などとの区別)
+        elif pos[idx] == '連体詞':
             x = 連体詞(wakati[idx])
             buf_pos.append(x)
-        elif pos[idx] == '形容詞':   # 副詞と連体詞は活用なし、形容詞は活用あり
+        elif pos[idx] == '形容詞':
             x = 形容詞(wakati[idx])
             buf_pos.append(x)
 
@@ -342,10 +342,23 @@ def parse(s: str, post_processing=post_processing) -> 系列:
                 x = 未定義(wakati[idx])
                 buf_pos.append(x)
                 print('@@未定義', wakati[idx], pos[idx], pos2[idx])
+
+        # ad hoc な実装
+        # e.g.: A と B を表示する
+        elif pos[idx] == 'フィラー':
+            if wakati[idx] == 'と':
+                x = 助詞(wakati[idx])
+                buf_pos.append(x)
+
+        elif pos[idx] == '感動詞':
+            if wakati[idx] == 'こんにちは':
+                x = 名詞(wakati[idx])
+                buf_pos.append(x)
+
         else:
             x = 未定義(wakati[idx])
             buf_pos.append(x)
-            print('@@未定義', wakati[idx], pos[idx], pos2[idx])
+            # print('@@未定義', wakati[idx], pos[idx], pos2[idx])
 
     s = 系列(*buf_pos)
 


### PR DESCRIPTION
以下、変更点です。

- 名詞 (サ変接続) + サ変動詞を一つの動詞として扱う (`join_s_verb`)
- 動詞の後ろに助動詞や接続助詞がある場合、一つにして動詞として扱う (`join_verb_attached`)
- PEGtree とjanome をマージしたことで正しく処理できない日本語を強制的にノードに代入 (ad hoc な実装)

これで、今までのterakoya ルールファイルの日本語はparse できるようになりました。